### PR TITLE
fix: disable parallel execution - static driver not thread-safe

### DIFF
--- a/testng.xml
+++ b/testng.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
-<suite name="Mobile Test Automation Suite" parallel="methods" thread-count="2" verbose="1">
+<suite name="Mobile Test Automation Suite" parallel="false" thread-count="1" verbose="1">
 
     <test name="Calculator Tests">
         <classes>


### PR DESCRIPTION
## Bug Fix

Parallel method execution with a `static AppiumDriver` causes all tests to race and crash each other, resulting in 0 tests running.

### Root Cause
`parallel=methods` starts multiple tests simultaneously. Since `BaseTest.driver` is static (shared), Thread 2 overwrites it before Thread 1 finishes, causing NullPointerExceptions and 0 passing tests.

### Fix
Reverted testng.xml to `parallel=false`, `thread-count=1`. All 10 tests now run sequentially and correctly.

### Closes Issue
Resolves test execution failure.